### PR TITLE
Fix: bug in gadget search comparison for null characters

### DIFF
--- a/src/search_gadgets.c
+++ b/src/search_gadgets.c
@@ -96,7 +96,7 @@ static void find_all_gadgets(t_binary *bin, t_asm *gadgets, unsigned int *NbGadF
         /* opcode mode */
         if (opcode_mode.flag)
           {
-            if(!strncmp((char *)data, (char *)opcode_mode.opcode, opcode_mode.size))
+            if(!memcmp((char *)data, (char *)opcode_mode.opcode, opcode_mode.size))
               {
                 uprintf("%s" ADDR_FORMAT "%s: \"%s", RED, ADDR_WIDTH, v_addr, ENDC, GREEN);
                 print_opcode();


### PR DESCRIPTION
Gadgets containing a null character were not compared properly. strncmp ignored everything after the first null character and invalid gadgets were found.
