### PR TITLE
Fixing offsets with execve syscall 

### DIFF
--- a/includes/ropgadget.h
+++ b/includes/ropgadget.h
@@ -352,7 +352,7 @@ void                    sc_print_sect_addr(int offset, int data, size_t bytes);
 
 /* makecode: Mid-level payload generation */
 void                    sc_print_sect_addr_pop(const t_gadget *, int, int, size_t);
-void                    sc_print_addr_pop(const t_gadget *, Address, const char *, size_t);
+void                    sc_print_number_pop(const t_gadget *, Size, const char *, size_t);
 void                    sc_print_raw_pop(const t_gadget *, const char *, size_t, size_t);
 void                    sc_print_str_pop(const t_gadget *, const char *, size_t);
 void                    sc_print_solo_inst(const t_gadget *, size_t);

--- a/src/x86/common_makecode.c
+++ b/src/x86/common_makecode.c
@@ -140,7 +140,7 @@ static void x86_makepartie2(t_gadget *gadgets, int argv_start, int envp_start, s
     for (i = 0; i != (word_size==4?0xb:0x3b); i++)
       sc_print_solo_inst(inc_eax, word_size);
   } else { /* Fallback eax/rax setting (Will add NULL BYTES) */
-    sc_print_addr_pop(pop_eax, (word_size==4?0xb:0x3b), " execve", word_size);
+    sc_print_number_pop(pop_eax, (word_size==4?0xb:0x3b), " execve", word_size);
   }
 
   if (word_size == 4) {


### PR DESCRIPTION
The shellcode generated for the Ubuntu 64b libc in Python format ends
with:
p += pack("<Q", off + 0x0000000000023950) # pop rax ; ret
p += pack("<Q", off + 0x000000000000003b) #  execve
p += pack("<Q", off + 0x0000000000001454) # syscall

Notice the offset being incorrectly added to the 3b literal for the
execve syscall. This results in nonfunctioning shell code. This patch
fixes that by:
1) Changing sc_print_addr_pop to sc_print_number_pop. The function is
only used once, and it's to print a numeric literal, not an address.
Popping a numeric literal should not add the library offset.
2) Adding a parameter to sc_print_code to dictate whether the value is
in the library and thus should be offset if a shared object.

With the patch applied, the resulting shell code for the same invocation
as above correctly ends in:
p += pack("<Q", off + 0x0000000000023950) # pop rax ; ret
p += pack("<Q", 0x000000000000003b) #  execve
p += pack("<Q", off + 0x0000000000001454) # syscall
