### PR TITLE
Split src

### DIFF
--- a/ropgadget/core.py
+++ b/ropgadget/core.py
@@ -299,3 +299,12 @@ class Core(cmd.Cmd):
         print "keyword  = with"
         print "!keyword = witout"
 
+
+    def do_count(self, s):
+        print "[*] %d loaded gadgets." % len(self.__gadgets)
+
+
+    def help_count(self):
+        print "Shows the number of loaded gadgets."
+
+


### PR DESCRIPTION
This patch fixes a bug in the --badbytes option.
Let's say that there's a gadget at address 0x0804c140; if I set --badbytes to "14", ROPgadget filters out that address, when it should not be filtered, because it's making a match taking parts from two bytes: the 1 from C1 and the 4 from 40.

Also, I've added the 'count' command to the console, which will just print out the number of loaded gadgets.
