### PR TITLE
Save2db

### DIFF
--- a/ropgadget/args.py
+++ b/ropgadget/args.py
@@ -53,6 +53,8 @@ architectures supported:
   load                 Load all gadgets
   quit                 Quit the console mode
   search               Search specific keywords or not
+  save2db              Saves the loaded gadgets to an sqlite database
+  loaddb               Loads gadgets from an sqlite database
 
 examples:
   ROPgadget.py --binary ./test-suite-binaries/elf-Linux-x86 


### PR DESCRIPTION
This pull request implements the save2db/loaddb console commands, which allows to save/load gadgets to/from an sqlite database, so you can save time when working repeatedly with the same binary (specially when the binary is big!).

Probably the feature could be easily integrated with the non-console mode; however have in mind that I'm saving to/loading from the DB only the 'vaddr' and 'gadget' fields of every dictionary in the self.__gadgets list, while ignoring the 'decodes' field.
