### PR TITLE
Added support for --multibr

### DIFF
--- a/ropgadget/args.py
+++ b/ropgadget/args.py
@@ -85,6 +85,7 @@ architectures supported:
         parser.add_argument("--norop",              action="store_true",              help="Disable ROP search engine")
         parser.add_argument("--nojop",              action="store_true",              help="Disable JOP search engine")
         parser.add_argument("--nosys",              action="store_true",              help="Disable SYS search engine")
+        parser.add_argument("--multibr",            action="store_true",              help="Enable multiple branch gadgets")
         self.__args = parser.parse_args()
 
         if self.__args.version:

--- a/ropgadget/core.py
+++ b/ropgadget/core.py
@@ -54,7 +54,7 @@ class Core(cmd.Cmd):
             if not self.__options.nosys: self.__gadgets += G.addSYSGadgets(section)
 
         # Pass clean single instruction and unknown instructions
-        self.__gadgets = G.passClean(self.__gadgets)
+        self.__gadgets = G.passClean(self.__gadgets, self.__options.multibr)
 
         # Delete duplicate gadgets
         self.__gadgets = rgutils.deleteDuplicateGadgets(self.__gadgets)
@@ -393,7 +393,7 @@ class Core(cmd.Cmd):
         print "ROPchain:    %s" %(self.__options.ropchain)
         print "String:      %s" %(self.__options.string)
         print "Thumb:       %s" %(self.__options.thumb)
-
+        print "MultiBr:     %s" %(self.__options.multibr)
 
     def help_settings(self):
         print "Display setting's environment"

--- a/ropgadget/gadgets.py
+++ b/ropgadget/gadgets.py
@@ -34,7 +34,7 @@ class Gadgets:
                 count += 1
         return count
 
-    def __passCleanX86(self, gadgets):
+    def __passCleanX86(self, gadgets, multibr=False):
         new = []
         br = ["ret", "int", "sysenter", "jmp", "call"]
         for gadget in gadgets:
@@ -45,7 +45,7 @@ class Gadgets:
                 continue
             if self.__checkInstructionBlackListedX86(insts):
                 continue
-            if self.__checkMultiBr(insts, br) > 1:
+            if not multibr and self.__checkMultiBr(insts, br) > 1:
                 continue
             if len([m.start() for m in re.finditer("ret", gadget["gadget"])]) > 1:
                 continue
@@ -189,8 +189,8 @@ class Gadgets:
 
         return self.__gadgetsFinding(section, gadgets)
 
-    def passClean(self, gadgets):
-        if   self.__binary.getArch() == CS_ARCH_X86:    return self.__passCleanX86(gadgets)
+    def passClean(self, gadgets, multibr):
+        if   self.__binary.getArch() == CS_ARCH_X86:    return self.__passCleanX86(gadgets, multibr)
         elif self.__binary.getArch() == CS_ARCH_MIPS:   return gadgets 
         elif self.__binary.getArch() == CS_ARCH_PPC:    return gadgets
         elif self.__binary.getArch() == CS_ARCH_SPARC:  return gadgets


### PR DESCRIPTION
I recently spent too much time looking for an initial gadget that could be used to gain control of stack and allow further execution. Manual examination of the binary yielded a gadget that ROPgadget had thrown out due to containing multiple branch instructions, often times a call + ret are perfectly usable.

The following example is derived from the target binary I was ropping against:

``` c
int main()
{
__asm__("call *0x10(%rax,%rbx)\n"
        "pop %r12\n"
        "pop %rbp\n"
        "ret");
return 0;
}
```

ROPgadget.py currently does not identify this gadget.

``` bash
navs@debian:~/ROPgadget$ ./ROPgadget.py --binary ~/test |grep 0x0000000000400478
navs@debian:~/ROPgadget$ 
```

I have added a multibr option that can be used to enable the display of gadgets that are currently discarded in
__passCleanX86.  

``` bash
navs@debian:~/ROPgadget.multibr$ ./ROPgadget.py --multibr --binary ~/test |grep 0x0000000000400478
0x0000000000400478 : call qword ptr [rax + rbx + 0x10] ; pop r12 ; pop rbp ; ret
```

Note: this gadget is still not identified by either the current ROPgadget or my branch as being the end of a gadget. I believe this to be a bug as other indirect calls are identified. I am looking into this and will submit a remedy when I sort it out.
