### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,14 @@ be found in the Archives directory but it will not be maintained.
 Install
 -------
 
-If you want to use ROPgadget, you have to install Capstone first.
+If you want to use ROPgadget, you have to install [Capstone](www.capstone-engine.org) first.
 
 For the Capstone's installation on nix machine:
 
-    $ cd ./dependencies/capstone-next
-    $ ./make.sh
-    $ sudo ./make.sh install
-    $ cd ./bindings/python
-    $ sudo make install
+    $ sudo pip install capstone
 
 Capstone supports multi-platforms (windows, ios, android, cygwin...). For the cross-compilation,
-please refer to the https://github.com/JonathanSalwan/ROPgadget/blob/dev/dependencies/capstone-next/COMPILE.TXT
-file.
+please refer to the https://github.com/aquynh/capstone/blob/master/COMPILE.TXT file.
 
 After Capstone is installed, ROPgadget can be used as a standalone tool:
 


### PR DESCRIPTION
From Capstone 3.0.1, it is possible to install everything with PyPi package: this includes both the core & Python binding.

This also changes the link to Capstone to the upstream version, so ROPgadget do not use out-of-date version.