### PR TITLE
Improve performance

### DIFF
--- a/ropgadget/gadgets.py
+++ b/ropgadget/gadgets.py
@@ -15,8 +15,6 @@ import re
 from   capstone import *
 
 
-# TODO make this more efficiente there are many calls to self.getarch and alike
-
 class Gadgets:
     def __init__(self, binary, options, offset):
         self.__binary  = binary

--- a/ropgadget/gadgets.py
+++ b/ropgadget/gadgets.py
@@ -117,7 +117,10 @@ class Gadgets:
             print "Gadgets().addROPGadgets() - Architecture not supported"
             return None
 
-        return self.__gadgetsFinding(section, gadgets, arch, arch_mode)
+        if len(gadgets) > 0 :
+            return self.__gadgetsFinding(section, gadgets, arch, arch_mode)
+        return gadgets
+
 
     def addJOPGadgets(self, section):
         arch = self.__binary.getArch()
@@ -125,7 +128,7 @@ class Gadgets:
 
 
 
-        if   arch  == CS_ARCH_X86:
+        if arch  == CS_ARCH_X86:
             gadgets = [
                                ["\xff[\x20\x21\x22\x23\x26\x27]{1}", 2, 1],     # jmp  [reg]
                                ["\xff[\xe0\xe1\xe2\xe3\xe4\xe6\xe7]{1}", 2, 1], # jmp  [reg]
@@ -171,7 +174,9 @@ class Gadgets:
             print "Gadgets().addJOPGadgets() - Architecture not supported"
             return None
 
-        return self.__gadgetsFinding(section, gadgets, arch, arch_mode)
+        if len(gadgets) > 0 :
+            return self.__gadgetsFinding(section, gadgets, arch, arch_mode)
+        return gadgets
 
     def addSYSGadgets(self, section):
 
@@ -195,7 +200,7 @@ class Gadgets:
         elif arch == CS_ARCH_ARM:
             if self.__options.thumb or self.__options.rawMode == "thumb":
                 gadgets = [
-                               ["\x00-\xff]{1}\xef", 2, 2], # svc
+                               ["\x00-\xff]{1}\xef", 2, 2] # svc
                           ]
                 arch_mode = CS_MODE_THUMB
             else:
@@ -207,7 +212,9 @@ class Gadgets:
             print "Gadgets().addSYSGadgets() - Architecture not supported"
             return None
 
-        return self.__gadgetsFinding(section, gadgets, arch, arch_mode)
+        if len(gadgets) > 0 :
+            return self.__gadgetsFinding(section, gadgets, arch, arch_mode)
+        return []
 
     def passClean(self, gadgets, multibr):
 

--- a/test-suite-binaries/test.sh
+++ b/test-suite-binaries/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+FILES=`ls`
+for f in $FILES
+do
+  if [ "$f" != "test.sh" ]
+  then
+    python ../ROPgadget.py --binary $f 1>/dev/null
+    echo "$f analyzed"
+  fi
+done


### PR DESCRIPTION
This pull request is to improve the performance of the tool since instead of call `self.__binary.getArch()` for each gadget is called once and used when is necessary. 

In the function `__gadgetsFinding` is create only once instance of Capstone and only is disassemble when the alignment is correct in this way we save time of computation.