### PR TITLE
input more one re

### DIFF
--- a/ropgadget/core.py
+++ b/ropgadget/core.py
@@ -599,7 +599,7 @@ class Core(cmd.Cmd):
         return False
 
     def help_re(self):
-        print("Syntax: re <pattern - Regular expression>")
+        print("Syntax: re <pattern1 | pattern2 |...> - Regular expression")
         return False
 
     def do_re(self, s, silent=False):

--- a/ropgadget/options.py
+++ b/ropgadget/options.py
@@ -77,14 +77,32 @@ class Options:
 
     def __reOption(self):
         new = []
-        pattern = re.compile(self.__options.re)
+        if not self.__options.re:
+            return
+        if '|' in self.__options.re:
+            re_strs = self.__options.re.split(' | ')
+            if 1 == len(re_strs):
+                re_strs = self.__options.re.split('|')
+        else:
+            re_strs = self.__options.re
+
+        patterns = []
+        for __re_str in re_strs:
+            pattern = re.compile(__re_str)
+            patterns.append(pattern)
+
         for gadget in self.__gadgets:
-            flag = 0
+            flag = 1
             insts = gadget["gadget"].split(" ; ")
-            for ins in insts:
-                res = pattern.search(ins)
-                if res:
-                    flag = 1
+            for pattern in patterns:
+                for ins in insts:
+                    res = pattern.search(ins)
+                    if res:
+                        flag = 1
+                        break
+                    else:
+                        flag = 0
+                if not flag:
                     break
             if flag:
                 new += [gadget]


### PR DESCRIPTION
My colleague say that he want to input more than one re to get the gadget. So i change the code.
for example:
(ROPgadget)> re mov r\d+, sp | bx lr
[+] Re setted. You have to reload gadgets
(ROPgadget)> load
[+] Loading gadgets, please wait...
[+] Gadgets loaded !
(ROPgadget)> display
Gadgets information
============================================================
0x000218d4 : **bx lr** ; mov ip, r7 ; mov r2, r1 ; mov r1, #1 ; mov r7, #0xf0 ; svc #0 ; mov r7, ip ; **bx lr** ; **mov r0, sp** ; **bx lr**
...
...
0x000218e4 : mov r7, #0xf0 ; svc #0 ; mov r7, ip ; **bx lr** ; **mov r0, sp** ; **bx lr**
0x000218ec : mov r7, ip ; **bx lr** ; **mov r0, sp** ; **bx lr**
0x000218e8 : svc #0 ; mov r7, ip ; **bx lr** ; **mov r0, sp** ; **bx lr**

Unique gadgets found: 9