### PR TITLE
Inconsistencies of created gadgets, due to backward dissas

### DIFF
--- a/ropgadget/gadgets.py
+++ b/ropgadget/gadgets.py
@@ -71,6 +71,8 @@ class Gadgets:
                         gadget = ""
                         for decode in decodes:
                             gadget += (decode.mnemonic + " " + decode.op_str + " ; ").replace("  ", " ")
+                        if re.search(gad[C_OP],decode.bytes) is None:
+                                continue
                         if len(gadget) > 0:
                             gadget = gadget[:-3]
                             off = self.__offset


### PR DESCRIPTION
Hi,

I think that I spotted a small bug in the process of creating gadgets.

When creating a gadget from a pattern, the backward dissas does not check if the last instruction generated is the same as the pattern.

In the example [test.txt](https://github.com/JonathanSalwan/ROPgadget/files/381738/test.txt), there are two instructions :

```bash
    add ebx, ebp
    ret 0x2e66
```
As hex: "01ebc2662e".
Which matches the [pattern](https://github.com/JonathanSalwan/ROPgadget/blob/master/ropgadget/gadgets.py#L88) [\xc2[\x00-\xff]{2}] 
Yet if you try to disassemble from the octet  "eb", you have "ebc2", which is a jump.
Then 66 2e are just garbages values.

Gadgets generated without the fix :

```bash
ROPgadget.py --binary test --depth 3 --dump
...
0x0000000000400080 : add ebx, ebp ; ret 0x2e66 // 01ebc2662e
0x0000000000400081 : jmp 0x400046 // ebc2662e
0x0000000000400082 : ret 0x2e66 // c2662e
```
With the fix: 
```bash
ROPgadget.py --binary test --depth 3 --dump
...
0x0000000000400080 : add ebx, ebp ; ret 0x2e66 // 01ebc2662e
0x0000000000400082 : ret 0x2e66 // c2662e
```

Josselin