### PR TITLE
Fixed issue #77

### DIFF
--- a/ropgadget/loaders/pe.py
+++ b/ropgadget/loaders/pe.py
@@ -76,7 +76,6 @@ class IMAGE_OPTIONAL_HEADER64(Structure):
                     ("SizeOfUninitializedData",     c_uint),
                     ("AddressOfEntryPoint",         c_uint),
                     ("BaseOfCode",                  c_uint),
-                    ("BaseOfData",                  c_uint),
                     ("ImageBase",                   c_ulonglong),
                     ("SectionAlignment",            c_uint),
                     ("FileAlignment",               c_uint),


### PR DESCRIPTION
https://github.com/JonathanSalwan/ROPgadget/issues/77
Due to invalid IMAGE_OPTIONAL_HEADER64 definition, ROPGadget reports
wrong addresses for x64 PE files.