### PR TITLE
Added 32 bit arm endianness support

### DIFF
--- a/ropgadget/args.py
+++ b/ropgadget/args.py
@@ -81,7 +81,7 @@ architectures supported:
         parser.add_argument("--badbytes",           type=str, metavar="<byte>",       help="Rejects specific bytes in the gadget's address")
         parser.add_argument("--rawArch",            type=str, metavar="<arch>",       help="Specify an arch for a raw file")
         parser.add_argument("--rawMode",            type=str, metavar="<mode>",       help="Specify a mode for a raw file")
-        parser.add_argument("--endian",             type=str, metavar="<endian>",     help="Specify endianness for a raw file")
+        parser.add_argument("--bigendian",          action="store_true",              help="Specify bigendian for this raw file")
         parser.add_argument("--re",                 type=str, metavar="<re>",         help="Regular expression")
         parser.add_argument("--offset",             type=str, metavar="<hexaddr>",    help="Specify an offset for gadget addresses")
         parser.add_argument("--ropchain",           action="store_true",              help="Enable the ROP chain generation")

--- a/ropgadget/args.py
+++ b/ropgadget/args.py
@@ -81,6 +81,7 @@ architectures supported:
         parser.add_argument("--badbytes",           type=str, metavar="<byte>",       help="Rejects specific bytes in the gadget's address")
         parser.add_argument("--rawArch",            type=str, metavar="<arch>",       help="Specify an arch for a raw file")
         parser.add_argument("--rawMode",            type=str, metavar="<mode>",       help="Specify a mode for a raw file")
+        parser.add_argument("--endian",             type=str, metavar="<endian>",     help="Specify endianness for a raw file")
         parser.add_argument("--re",                 type=str, metavar="<re>",         help="Regular expression")
         parser.add_argument("--offset",             type=str, metavar="<hexaddr>",    help="Specify an offset for gadget addresses")
         parser.add_argument("--ropchain",           action="store_true",              help="Enable the ROP chain generation")

--- a/ropgadget/core.py
+++ b/ropgadget/core.py
@@ -428,6 +428,7 @@ class Core(cmd.Cmd):
         print("Only:        %s" %(self.__options.only))
         print("Opcode:      %s" %(self.__options.opcode))
         print("ROPchain:    %s" %(self.__options.ropchain))
+        print("BigEndian:   %s" %(self.__options.bigendian))
         print("Range:       %s" %(self.__options.range))
         print("RawArch:     %s" %(self.__options.rawArch))
         print("RawMode:     %s" %(self.__options.rawMode))
@@ -546,6 +547,32 @@ class Core(cmd.Cmd):
 
     def help_thumb(self):
         print("Syntax: thumb <enable|disable> - Use the thumb mode for the search engine (ARM only)")
+        return False
+    
+    def do_bigendian(self, s, silent=False):
+        try:
+            arg = s.split()[0]
+        except:
+            return self.help_bigendian()
+
+        if arg == "enable":
+            self.__options.bigendian = True
+            if not silent:
+                print("[+] bigendian enable. You have to reload gadgets")
+
+        elif arg == "disable":
+            self.__options.bigendian = False
+            if not silent:
+                print("[+] bigendian disable. You have to reload gadgets")
+
+        else:
+            if not silent:
+                return self.help_bigendian()
+            return False
+
+
+    def help_bigendian(self):
+        print("Syntax: bigendian <enable|disable> - Use the bigendian mode for the search engine (ARM only)")
         return False
 
 

--- a/ropgadget/gadgets.py
+++ b/ropgadget/gadgets.py
@@ -128,7 +128,7 @@ class Gadgets(object):
     def addJOPGadgets(self, section):
         arch = self.__binary.getArch()
         arch_mode = self.__binary.getArchMode()
-        endianness = self.__options.endian
+        endianness = self.__options.bigendian
 
         if arch  == CS_ARCH_X86:
             gadgets = [


### PR DESCRIPTION
This change allows ROPgadget to search for gadgets in arm and thumb code that has been compiled with the -mbig-endian flag in GCC. Previously only little endian arm hex files could be correctly searched by ROPgadget