### PR TITLE
Return zero on success otherwise error 1

### DIFF
--- a/ropgadget/__init__.py
+++ b/ropgadget/__init__.py
@@ -21,4 +21,4 @@ def main():
     import sys
     from   ropgadget.args import Args
     from   ropgadget.core import Core
-    sys.exit(Core(Args().getArgs()).analyze())
+    sys.exit(0 if Core(Args().getArgs()).analyze() else 1)


### PR DESCRIPTION
returning True from the API is a valid value, however using it as sys.exit value converts it to a non-expected value as True maps to 1 and False to 0 while 0 is used to indicate success.