### PR TITLE
Add blacklisted instructions for arm64.

### DIFF
--- a/ropgadget/gadgets.py
+++ b/ropgadget/gadgets.py
@@ -50,6 +50,20 @@ class Gadgets(object):
             new += [gadget]
         return new
 
+    def __passCleanArm64(self, gadgets, multibr=False):
+        new = []
+        bl = ["brk", "smc", "hvc"]
+        for gadget in gadgets:
+            insts = gadget["gadget"].split(" ; ")
+            isbl = False;
+            for inst in insts:
+                if inst.split(" ")[0] in bl:
+                    isbl = True;
+            if isbl:
+                continue
+            new += [gadget]
+        return new
+
     def __gadgetsFinding(self, section, gadgets, arch, mode):
 
         C_OP    = 0
@@ -238,7 +252,7 @@ class Gadgets(object):
         elif arch == CS_ARCH_PPC:    return gadgets
         elif arch == CS_ARCH_SPARC:  return gadgets
         elif arch == CS_ARCH_ARM:    return gadgets
-        elif arch == CS_ARCH_ARM64:  return gadgets
+        elif arch == CS_ARCH_ARM64:  return self.__passCleanArm64(gadgets, multibr)
         else:
             print("Gadgets().passClean() - Architecture not supported")
             return None


### PR DESCRIPTION
I have been using ROPGadget to enumerate gadgets on arm64 binaries, and noticed that it will include gadgets that have bad instructions in them. This PR adds a filter function for 'brk', 'hvc', and 'smc' to screen out gadgets that have these instructions.