### PR TITLE
fix wrong search in range implementation

### DIFF
--- a/ropgadget/core.py
+++ b/ropgadget/core.py
@@ -38,7 +38,7 @@ class Core(cmd.Cmd):
         """
         given a section and a range, edit the section so that all opcodes are within the range
         """
-        if not self.__options.range:
+        if self.__options.range == "0x0-0x0":
             return section
 
         rangeStart, rangeEnd = map(lambda x:int(x, 16), self.__options.range.split('-'))

--- a/ropgadget/gadgets.py
+++ b/ropgadget/gadgets.py
@@ -68,7 +68,7 @@ class Gadgets(object):
                         for decode in decodes:
                             gadget += (decode.mnemonic + " " + decode.op_str + " ; ").replace("  ", " ")
                         if re.search(gad[C_OP],decode.bytes) is None:
-                                continue
+                            continue
                         if len(gadget) > 0:
                             gadget = gadget[:-3]
                             off = self.__offset


### PR DESCRIPTION
*Symptom*:
The logic before is like this:
1. find all gadgets in the whole binary
2. delete duplicates gadget and sort gadgets
3. look for desired gadget within the range

there are two problems of this implementation
1. wrong logic.
we want gadgets within the range,  but those gadgets could be duplicates of previous gadgets. But duplicates have been deleted in step2. So we actually get much less gadgets and those missing gadgets  could be the most common ones.
2. takes too much time.
Now that we want everything within the range, why bother going through the whole binary?

*Fix*
The new implementation works like this.
Each time we want a section(should be a segment?), we take the intersection of the search range and the section and modify `offset`,`vaddr` and `size` accordingly. In this way, we can solve both the problems mentioned above.