### PR TITLE
Fix issue with python 3.7.5

### DIFF
--- a/ropgadget/core.py
+++ b/ropgadget/core.py
@@ -12,6 +12,7 @@ import re
 import codecs
 import ropgadget.rgutils as rgutils
 import sqlite3
+import binascii
 
 from ropgadget.binary             import Binary
 from capstone                     import CS_MODE_32
@@ -108,7 +109,7 @@ class Core(cmd.Cmd):
             vaddr = gadget["vaddr"]
             insts = gadget["gadget"]
             bytes = gadget["bytes"]
-            bytesStr = " // " + bytes.encode('hex') if self.__options.dump else ""
+            bytesStr = " // " + binascii.hexlify(bytes).decode('utf8') if self.__options.dump else ""
 
             print(("0x%08x" %(vaddr) if arch == CS_MODE_32 else "0x%016x" %(vaddr)) + " : %s" %(insts) + bytesStr)
 


### PR DESCRIPTION
```bash
eg. ROPgadget --binary /bin/ls --dump --all --depth 6
```
Generates the following stack trace
```python
============================================================
Traceback (most recent call last):
  File "/usr/local/bin/ROPgadget", line 4, in <module>
    __import__('pkg_resources').run_script('ROPGadget==5.7', 'ROPgadget')
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 666, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 1460, in run_script
    exec(script_code, namespace, namespace)
  File "/usr/local/lib/python3.7/site-packages/ROPGadget-5.7-py3.7.egg/EGG-INFO/scripts/ROPgadget", line 12, in <module>
  File "/usr/local/lib/python3.7/site-packages/ROPGadget-5.7-py3.7.egg/ropgadget/__init__.py", line 24, in main
  File "/usr/local/lib/python3.7/site-packages/ROPGadget-5.7-py3.7.egg/ropgadget/core.py", line 206, in analyze
  File "/usr/local/lib/python3.7/site-packages/ROPGadget-5.7-py3.7.egg/ropgadget/core.py", line 111, in __lookingForGadgets
AttributeError: 'bytes' object has no attribute 'encode'
```