### PR TITLE
Improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ Usage
                         [--string <string>] [--memstr <string>] [--depth <nbyte>]
                         [--only <key>] [--filter <key>] [--range <start-end>]
                         [--badbytes <byte>] [--rawArch <arch>] [--rawMode <mode>]
-                        [--re <re>] [--offset <hexaddr>] [--ropchain] [--thumb]
-                        [--console] [--norop] [--nojop] [--nosys] [--multibr]
-                        [--all] [--dump]
+                        [--rawEndian <endian>] [--re <re>] [--offset <hexaddr>]
+                        [--ropchain] [--thumb] [--console] [--norop] [--nojop]
+                        [--callPreceded] [--nosys] [--multibr] [--all] [--noinstr]
+                        [--dump]
 
     optional arguments:
         -h, --help           show this help message and exit
@@ -59,6 +60,7 @@ Usage
         --badbytes <byte>    Rejects specific bytes in the gadget's address
         --rawArch <arch>     Specify an arch for a raw file
         --rawMode <mode>     Specify a mode for a raw file
+        --rawEndian <endian> Specify an endianness for a raw file
         --re <re>            Regular expression
         --offset <hexaddr>   Specify an offset for gadget addresses
         --ropchain           Enable the ROP chain generation
@@ -66,10 +68,11 @@ Usage
         --console            Use an interactive console for search engine
         --norop              Disable ROP search engine
         --nojop              Disable JOP search engine
-        --callPreceded       Only show gadgets which are call-preceded (x86 only)
+        --callPreceded       Only show gadgets which are call-preceded
         --nosys              Disable SYS search engine
         --multibr            Enable multiple branch gadgets
         --all                Disables the removal of duplicate gadgets
+        --noinstr            Disable the gadget instructions console printing
         --dump               Outputs the gadget bytes
 
 

--- a/ropgadget/args.py
+++ b/ropgadget/args.py
@@ -56,7 +56,7 @@ architectures supported:
   ROPgadget.py --binary ./test-suite-binaries/elf-Linux-x86 --opcode c9c3
   ROPgadget.py --binary ./test-suite-binaries/elf-Linux-x86 --only "mov|ret"
   ROPgadget.py --binary ./test-suite-binaries/elf-Linux-x86 --only "mov|pop|xor|ret"
-  ROPgadget.py --binary ./test-suite-binaries/elf-Linux-x86 --filter "xchg|add|sub"
+  ROPgadget.py --binary ./test-suite-binaries/elf-Linux-x86 --filter "xchg|add|sub|cmov.*"
   ROPgadget.py --binary ./test-suite-binaries/elf-Linux-x86 --norop --nosys
   ROPgadget.py --binary ./test-suite-binaries/elf-Linux-x86 --range 0x08041000-0x08042000
   ROPgadget.py --binary ./test-suite-binaries/elf-Linux-x86 --string main --range 0x080c9aaa-0x080c9aba
@@ -76,7 +76,7 @@ architectures supported:
         parser.add_argument("--memstr",             type=str, metavar="<string>",     help="Search each byte in all readable segment")
         parser.add_argument("--depth",              type=int, metavar="<nbyte>",      default=10, help="Depth for search engine (default 10)")
         parser.add_argument("--only",               type=str, metavar="<key>",        help="Only show specific instructions")
-        parser.add_argument("--filter",             type=str, metavar="<key>",        help="Suppress specific instructions")
+        parser.add_argument("--filter",             type=str, metavar="<key>",        help="Suppress specific mnemonics")
         parser.add_argument("--range",              type=str, metavar="<start-end>",  default="0x0-0x0", help="Search between two addresses (0x...-0x...)")
         parser.add_argument("--badbytes",           type=str, metavar="<byte>",       help="Rejects specific bytes in the gadget's address")
         parser.add_argument("--rawArch",            type=str, metavar="<arch>",       help="Specify an arch for a raw file")
@@ -93,9 +93,18 @@ architectures supported:
         parser.add_argument("--nosys",              action="store_true",              help="Disable SYS search engine")
         parser.add_argument("--multibr",            action="store_true",              help="Enable multiple branch gadgets")
         parser.add_argument("--all",                action="store_true",              help="Disables the removal of duplicate gadgets")
+        parser.add_argument("--noinstr",            action="store_true",              help="Disable the gadget instructions console printing")
         parser.add_argument("--dump",               action="store_true",              help="Outputs the gadget bytes")
 
         self.__args = parser.parse_args(arguments)
+
+        if self.__args.noinstr and self.__args.only:
+            print("[Error] --noinstr and --only=<key> can't be used together")
+            sys.exit(-1)
+
+        if self.__args.noinstr and self.__args.re:
+            print("[Error] --noinstr and --re=<re> can't be used together")
+            sys.exit(-1)
 
         if self.__args.version:
             self.__printVersion()

--- a/ropgadget/options.py
+++ b/ropgadget/options.py
@@ -1,10 +1,10 @@
 ## -*- coding: utf-8 -*-
 ##
 ##  Jonathan Salwan - 2014-05-17 - ROPgadget tool
-## 
+##
 ##  http://twitter.com/JonathanSalwan
 ##  http://shell-storm.org/project/ROPgadget/
-## 
+##
 
 import re
 import codecs
@@ -15,40 +15,21 @@ class Options(object):
     def __init__(self, options, binary, gadgets):
         self.__options = options
         self.__gadgets = gadgets
-        self.__binary  = binary 
+        self.__binary  = binary
 
-        if options.filter:   self.__filterOption()
         if options.only:     self.__onlyOption()
         if options.range:    self.__rangeOption()
         if options.re:       self.__reOption()
         if options.badbytes: self.__deleteBadBytes()
         if options.callPreceded: self.__removeNonCallPreceded()
 
-    def __filterOption(self):
-        new = []
-        if not self.__options.filter:
-            return 
-        filt = self.__options.filter.split("|")
-        if not len(filt):
-            return 
-        for gadget in self.__gadgets:
-            flag = 0
-            insts = gadget["gadget"].split(" ; ")
-            for ins in insts:
-                if ins.split(" ")[0] in filt:
-                    flag = 1
-                    break
-            if not flag:
-                new += [gadget]
-        self.__gadgets = new
-
     def __onlyOption(self):
         new = []
         if not self.__options.only:
-            return 
+            return
         only = self.__options.only.split("|")
         if not len(only):
-            return 
+            return
         for gadget in self.__gadgets:
             flag = 0
             insts = gadget["gadget"].split(" ; ")
@@ -65,7 +46,7 @@ class Options(object):
         rangeS = int(self.__options.range.split('-')[0], 16)
         rangeE = int(self.__options.range.split('-')[1], 16)
         if rangeS == 0 and rangeE == 0:
-            return 
+            return
         for gadget in self.__gadgets:
             vaddr = gadget["vaddr"]
             if vaddr >= rangeS and vaddr <= rangeE:
@@ -107,7 +88,7 @@ class Options(object):
             if flag:
                 new += [gadget]
         self.__gadgets = new
-    
+
     def __removeNonCallPreceded(self):
         def __isGadgetCallPreceded(gadget):
             # Given a gadget, determine if the bytes immediately preceding are a call instruction
@@ -116,8 +97,8 @@ class Options(object):
             callPrecededExpressions = [
                 "\xe8[\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff]$",
                 "\xe8[\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff]$",
-                "\xff[\x00-\xff]$", 
-                "\xff[\x00-\xff][\x00-\xff]$", 
+                "\xff[\x00-\xff]$",
+                "\xff[\x00-\xff][\x00-\xff]$",
                 "\xff[\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff]$"
                 "\xff[\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff]$"
             ]


### PR DESCRIPTION
1. Improve speed by using disasm_lite
2. Reduce memory consumption. Don't save decodes object (was no use at
all). Save prev bytes only if --callPreceded presented. Save raw bytes
only if --dump presented.
3. Refactor passClean method to combine blacklisting and filtering. As
bonus, it is possible to provide regexp in --filter.
4. Add option --noinstr to disable the gadget instruction console
printing.