### PR TITLE
adding mipsrop

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Usage
         --dump               Outputs the gadget bytes
         --silent             Disables printing of gadgets during analysis
         --align ALIGN        Align gadgets addresses (in bytes)
+        --mipsrop <rtype>    Mips useful gadgets finder
 
 How can I contribute ?
 ----------------------

--- a/ropgadget/args.py
+++ b/ropgadget/args.py
@@ -97,6 +97,7 @@ architectures supported:
         parser.add_argument("--dump",               action="store_true",              help="Outputs the gadget bytes")
         parser.add_argument("--silent",             action="store_true",              help="Disables printing of gadgets during analysis")
         parser.add_argument("--align",              type=int,                         help="Align gadgets addresses (in bytes)")
+        parser.add_argument("--mipsrop",            type=str, metavar="<rtype>",help="Mips useful gadgets finder")
 
         self.__args = parser.parse_args(arguments)
 

--- a/ropgadget/core.py
+++ b/ropgadget/core.py
@@ -117,15 +117,14 @@ class Core(cmd.Cmd):
         return True
 
     def __lookingForMIPSgadgets(self,mips_option):
+        
         if self.__checksBeforeManipulations() == False:
             return False
-
+        
         if self.__options.silent:
             return True
-
-        dataSections = self.__binary.getDataSections()
-        arch = self.__binary.getArchMode()
         
+        arch = self.__binary.getArchMode()        
         if(mips_option=='stackfinder'):
             mipsFindRegex = ['addiu .*, \\$sp']
         elif(mips_option=='system'):


### PR DESCRIPTION
this helps to find useful gadgets for mips, its inspired by https://github.com/tacnetsol/ida/tree/master/plugins/mipsrop
searches based on regexes
this was made after iceCTF with @harsh_khuha

_____
available options for --mipsrop arg

	registers
	gadgets that put stack values into a register. (useful to control registers values)

	stackfinder
	gadgets that put a stack address into a register. (useful to load shellcode address into register)

	system
	gadgets that put a stack address into $a0. (useful to call system())

	tails
	tail call gadgets. (useful for function calls)

	lia0
	gadgets that load an immediate value number into $a0. (useful for setting up the argument to sleep)