### PR TITLE
Don't rely on native endianness

### DIFF
--- a/ropgadget/binary.py
+++ b/ropgadget/binary.py
@@ -42,7 +42,8 @@ class Binary(object):
             self.__binary = PE(self.__rawBinary)
         elif self.__rawBinary[:4] == unhexlify(b"cafebabe"):
             self.__binary = UNIVERSAL(self.__rawBinary)
-        elif self.__rawBinary[:4] == unhexlify(b"cefaedfe") or self.__rawBinary[:4] == unhexlify(b"cffaedfe"):
+        elif self.__rawBinary[:4] == unhexlify(b"cefaedfe") or self.__rawBinary[:4] == unhexlify(b"cffaedfe") or \
+             self.__rawBinary[:4] == unhexlify(b"feedface") or self.__rawBinary[:4] == unhexlify(b"feedfacf"):
             self.__binary = MACHO(self.__rawBinary)
         else:
             print("[Error] Binary format not supported")

--- a/ropgadget/loaders/macho.py
+++ b/ropgadget/loaders/macho.py
@@ -11,7 +11,18 @@ from ctypes import *
 from capstone import *
 
 
-class MACH_HEADER(Structure):
+class MACH_HEADER_LE(LittleEndianStructure):
+    _fields_ = [
+                ("magic",           c_uint),
+                ("cputype",         c_uint),
+                ("cpusubtype",      c_uint),
+                ("filetype",        c_uint),
+                ("ncmds",           c_uint),
+                ("sizeofcmds",      c_uint),
+                ("flags",           c_uint),
+               ]
+
+class MACH_HEADER_BE(BigEndianStructure):
     _fields_ = [
                 ("magic",           c_uint),
                 ("cputype",         c_uint),
@@ -23,14 +34,35 @@ class MACH_HEADER(Structure):
                ]
 
 
-class LOAD_COMMAND(Structure):
+class LOAD_COMMAND_LE(LittleEndianStructure):
+    _fields_ = [
+                ("cmd",             c_uint),
+                ("cmdsize",         c_uint),
+               ]
+
+class LOAD_COMMAND_BE(BigEndianStructure):
     _fields_ = [
                 ("cmd",             c_uint),
                 ("cmdsize",         c_uint),
                ]
 
 
-class SEGMENT_COMMAND(Structure):
+class SEGMENT_COMMAND_LE(LittleEndianStructure):
+    _fields_ = [
+                ("cmd",             c_uint),
+                ("cmdsize",         c_uint),
+                ("segname",         c_ubyte * 16),
+                ("vmaddr",          c_uint),
+                ("vmsize",          c_uint),
+                ("fileoff",         c_uint),
+                ("filesize",        c_uint),
+                ("maxprot",         c_uint),
+                ("initprot",        c_uint),
+                ("nsects",          c_uint),
+                ("flags",           c_uint),
+               ]
+
+class SEGMENT_COMMAND_BE(BigEndianStructure):
     _fields_ = [
                 ("cmd",             c_uint),
                 ("cmdsize",         c_uint),
@@ -46,7 +78,22 @@ class SEGMENT_COMMAND(Structure):
                ]
 
 
-class SEGMENT_COMMAND64(Structure):
+class SEGMENT_COMMAND64_LE(LittleEndianStructure):
+    _fields_ = [
+                ("cmd",             c_uint),
+                ("cmdsize",         c_uint),
+                ("segname",         c_ubyte * 16),
+                ("vmaddr",          c_ulonglong),
+                ("vmsize",          c_ulonglong),
+                ("fileoff",         c_ulonglong),
+                ("filesize",        c_ulonglong),
+                ("maxprot",         c_uint),
+                ("initprot",        c_uint),
+                ("nsects",          c_uint),
+                ("flags",           c_uint),
+               ]
+
+class SEGMENT_COMMAND64_BE(BigEndianStructure):
     _fields_ = [
                 ("cmd",             c_uint),
                 ("cmdsize",         c_uint),
@@ -62,7 +109,22 @@ class SEGMENT_COMMAND64(Structure):
                ]
 
 
-class SECTION(Structure):
+class SECTION_LE(LittleEndianStructure):
+    _fields_ = [
+                ("sectname",        c_ubyte * 16),
+                ("segname",         c_ubyte * 16),
+                ("addr",            c_uint),
+                ("size",            c_uint),
+                ("offset",          c_uint),
+                ("align",           c_uint),
+                ("reloff",          c_uint),
+                ("nreloc",          c_uint),
+                ("flags",           c_uint),
+                ("reserved1",       c_uint),
+                ("reserved2",       c_uint),
+               ]
+
+class SECTION_BE(BigEndianStructure):
     _fields_ = [
                 ("sectname",        c_ubyte * 16),
                 ("segname",         c_ubyte * 16),
@@ -78,7 +140,22 @@ class SECTION(Structure):
                ]
 
 
-class SECTION64(Structure):
+class SECTION64_LE(LittleEndianStructure):
+    _fields_ = [
+                ("sectname",        c_ubyte * 16),
+                ("segname",         c_ubyte * 16),
+                ("addr",            c_ulonglong),
+                ("size",            c_ulonglong),
+                ("offset",          c_uint),
+                ("align",           c_uint),
+                ("reloff",          c_uint),
+                ("nreloc",          c_uint),
+                ("flags",           c_uint),
+                ("reserved1",       c_uint),
+                ("reserved2",       c_uint),
+               ]
+
+class SECTION64_BE(BigEndianStructure):
     _fields_ = [
                 ("sectname",        c_ubyte * 16),
                 ("segname",         c_ubyte * 16),
@@ -116,14 +193,29 @@ class MACHO(object):
         self.__binary = bytearray(binary)
 
         self.__machHeader   = None
+        self.__endianness   = None
         self.__rawLoadCmd   = None
         self.__sections_l   = []
 
+        self.__setEndianness()
         self.__setHeader()
         self.__setLoadCmd()
 
+    def __setEndianness(self):
+        magic = self.__binary[0] << 24 | \
+                self.__binary[1] << 16 | \
+                self.__binary[2] <<  8 | \
+                self.__binary[3]
+        if magic == 0xfeedface or magic == 0xfeedfacf:
+            self.__endianness = CS_MODE_BIG_ENDIAN
+        else:
+            self.__endianness = 0
+
     def __setHeader(self):
-        self.__machHeader = MACH_HEADER.from_buffer_copy(self.__binary)
+        if self.__endianness == CS_MODE_BIG_ENDIAN:
+            self.__machHeader = MACH_HEADER_BE.from_buffer_copy(self.__binary)
+        else:
+            self.__machHeader = MACH_HEADER_LE.from_buffer_copy(self.__binary)
 
         if self.getArchMode() == CS_MODE_32:
             self.__rawLoadCmd   = self.__binary[28:28 + self.__machHeader.sizeofcmds]
@@ -134,14 +226,24 @@ class MACHO(object):
     def __setLoadCmd(self):
         base = self.__rawLoadCmd
         for _ in range(self.__machHeader.ncmds):
-            command = LOAD_COMMAND.from_buffer_copy(base)
+            if self.__endianness == CS_MODE_BIG_ENDIAN:
+                command = LOAD_COMMAND_BE.from_buffer_copy(base)
+            else:
+                command = LOAD_COMMAND_LE.from_buffer_copy(base)
 
             if command.cmd == MACHOFlags.LC_SEGMENT:
-                segment = SEGMENT_COMMAND.from_buffer_copy(base)
+                if self.__endianness == CS_MODE_BIG_ENDIAN:
+                    segment = SEGMENT_COMMAND_BE.from_buffer_copy(base)
+                else:
+                    segment = SEGMENT_COMMAND_LE.from_buffer_copy(base)
+
                 self.__setSections(segment, base[56:], 32)
 
             elif command.cmd == MACHOFlags.LC_SEGMENT_64:
-                segment = SEGMENT_COMMAND64.from_buffer_copy(base)
+                if self.__endianness == CS_MODE_BIG_ENDIAN:
+                    segment = SEGMENT_COMMAND64_BE.from_buffer_copy(base)
+                else:
+                    segment = SEGMENT_COMMAND64_LE.from_buffer_copy(base)
                 self.__setSections(segment, base[72:], 64)
 
             base = base[command.cmdsize:]
@@ -149,12 +251,18 @@ class MACHO(object):
     def __setSections(self, segment, base, sizeHeader):
         for _ in range(segment.nsects):
             if sizeHeader == 32:
-                section = SECTION.from_buffer_copy(base)
+                if self.__endianness == CS_MODE_BIG_ENDIAN:
+                    section = SECTION_BE.from_buffer_copy(base)
+                else:
+                    section = SECTION_LE.from_buffer_copy(base)
                 section.offset = segment.fileoff + section.addr - segment.vmaddr
                 base = base[68:]
                 self.__sections_l += [section]
             elif sizeHeader == 64:
-                section = SECTION64.from_buffer_copy(base)
+                if self.__endianness == CS_MODE_BIG_ENDIAN:
+                    section = SECTION64_BE.from_buffer_copy(base)
+                else:
+                    section = SECTION64_LE.from_buffer_copy(base)
                 section.offset = segment.fileoff + section.addr - segment.vmaddr
                 base = base[80:]
                 self.__sections_l += [section]
@@ -211,8 +319,9 @@ class MACHO(object):
         return None
 
     def getEndian(self):
-        # TODO: Support other endianness
-        return 0
+        if self.__endianness is None:
+            print("[Error] MACHO.getEndian() - Unable to determine endianness")
+        return self.__endianness
 
     def getFormat(self):
         return "Mach-O"

--- a/ropgadget/loaders/pe.py
+++ b/ropgadget/loaders/pe.py
@@ -23,7 +23,7 @@ class PEFlags(object):
     IMAGE_SIZEOF_SHORT_NAME       = 0x8
 
 
-class IMAGE_FILE_HEADER(Structure):
+class IMAGE_FILE_HEADER(LittleEndianStructure):
     _fields_ =  [
                     ("Magic",                       c_uint),
                     ("Machine",                     c_ushort),
@@ -36,7 +36,7 @@ class IMAGE_FILE_HEADER(Structure):
                 ]
 
 
-class IMAGE_OPTIONAL_HEADER(Structure):
+class IMAGE_OPTIONAL_HEADER(LittleEndianStructure):
     _fields_ =  [
                     ("Magic",                       c_ushort),
                     ("MajorLinkerVersion",          c_ubyte),
@@ -71,7 +71,7 @@ class IMAGE_OPTIONAL_HEADER(Structure):
                 ]
 
 
-class IMAGE_OPTIONAL_HEADER64(Structure):
+class IMAGE_OPTIONAL_HEADER64(LittleEndianStructure):
     _fields_ =  [
                     ("Magic",                       c_ushort),
                     ("MajorLinkerVersion",          c_ubyte),
@@ -105,7 +105,7 @@ class IMAGE_OPTIONAL_HEADER64(Structure):
                 ]
 
 
-class IMAGE_NT_HEADERS(Structure):
+class IMAGE_NT_HEADERS(LittleEndianStructure):
     _fields_ =  [
                     ("Signature",       c_uint),
                     ("FileHeader",      IMAGE_FILE_HEADER),
@@ -113,7 +113,7 @@ class IMAGE_NT_HEADERS(Structure):
                 ]
 
 
-class IMAGE_NT_HEADERS64(Structure):
+class IMAGE_NT_HEADERS64(LittleEndianStructure):
     _fields_ =  [
                     ("Signature",       c_uint),
                     ("FileHeader",      IMAGE_FILE_HEADER),
@@ -121,7 +121,7 @@ class IMAGE_NT_HEADERS64(Structure):
                 ]
 
 
-class IMAGE_SECTION_HEADER(Structure):
+class IMAGE_SECTION_HEADER(LittleEndianStructure):
     _fields_ =  [
                     ("Name",                    c_ubyte * PEFlags.IMAGE_SIZEOF_SHORT_NAME),
                     ("PhysicalAddress",         c_uint),


### PR DESCRIPTION
The loader for PE and Mach-O files relies on the native endianness of the host machine. This will fail when reading files for machines with a different endianness. This PR fixes all locations where the native endianness is applied.

This behavior was discovered during execution of the test suite on a PowerPC machine (big endian). See: https://bugs.gentoo.org/865149:

```
RUN core
RUN elf-ARM64-bash
RUN elf-ARMv7-ls
RUN elf-FreeBSD-x86
RUN elf-Linux-x64
RUN elf-Linux-x86
RUN elf-Linux-x86-NDH-chall
RUN elf-Mips-Defcon-20-pwn100
RUN elf-PowerPC-bash
RUN elf-PPC64-bash
RUN elf-SparcV8-bash
RUN elf-x64-bash-v4.1.5.1
RUN elf-x86-bash-v4.1.5.1
RUN Linux_lib32.so
RUN Linux_lib64.so
RUN macho-x64-ls
Traceback (most recent call last):
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/test-suite-binaries/../ROPgadget.py", line 12, in <module>
    ropgadget.main()
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/__init__.py", line 30, in main
    sys.exit(0 if Core(args.getArgs()).analyze() else 1)
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/core.py", line 244, in analyze
    self.__binary = Binary(self.__options)
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/binary.py", line 46, in __init__
    self.__binary = MACHO(self.__rawBinary)
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/loaders/macho.py", line 123, in __init__
    self.__setLoadCmd()
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/loaders/macho.py", line 137, in __setLoadCmd
    command = LOAD_COMMAND.from_buffer_copy(base)
TypeError: a bytes-like object is required, not 'NoneType'
RUN macho-x86-ls
Traceback (most recent call last):
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/test-suite-binaries/../ROPgadget.py", line 12, in <module>
    ropgadget.main()
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/__init__.py", line 30, in main
    sys.exit(0 if Core(args.getArgs()).analyze() else 1)
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/core.py", line 244, in analyze
    self.__binary = Binary(self.__options)
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/binary.py", line 46, in __init__
    self.__binary = MACHO(self.__rawBinary)
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/loaders/macho.py", line 123, in __init__
    self.__setLoadCmd()
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/loaders/macho.py", line 137, in __setLoadCmd
    command = LOAD_COMMAND.from_buffer_copy(base)
TypeError: a bytes-like object is required, not 'NoneType'
RUN pe-Windows-ARMv7-Thumb2LE-HelloWorld
Traceback (most recent call last):
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/test-suite-binaries/../ROPgadget.py", line 12, in <module>
    ropgadget.main()
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/__init__.py", line 30, in main
    sys.exit(0 if Core(args.getArgs()).analyze() else 1)
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/core.py", line 244, in analyze
    self.__binary = Binary(self.__options)
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/binary.py", line 42, in __init__
    self.__binary = PE(self.__rawBinary)
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/loaders/pe.py", line 154, in __init__
    self.__parseSections()
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/loaders/pe.py", line 185, in __parseSections
    sec = IMAGE_SECTION_HEADER.from_buffer_copy(base)
ValueError: Buffer size too small (0 instead of at least 40 bytes)
RUN pe-x64-cmd-v6.1.7601
RUN pe-x86-cmd-v6.1.7600
RUN raw-x86.raw
RUN UNIVERSAL-x86-x64-libSystem.B.dylib
Traceback (most recent call last):
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/test-suite-binaries/../ROPgadget.py", line 12, in <module>
    ropgadget.main()
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/__init__.py", line 30, in main
    sys.exit(0 if Core(args.getArgs()).analyze() else 1)
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/core.py", line 244, in analyze
    self.__binary = Binary(self.__options)
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/binary.py", line 44, in __init__
    self.__binary = UNIVERSAL(self.__rawBinary)
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/loaders/universal.py", line 61, in __init__
    self.__setBinaries()
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/loaders/universal.py", line 72, in __setBinaries
    self.__machoBinaries.append(MACHO(rawBinary))
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/loaders/macho.py", line 123, in __init__
    self.__setLoadCmd()
  File "/var/tmp/portage/dev-util/ROPgadget-6.9/work/ROPgadget-6.9/ropgadget/loaders/macho.py", line 137, in __setLoadCmd
    command = LOAD_COMMAND.from_buffer_copy(base)
TypeError: a bytes-like object is required, not 'NoneType'
RUN elf-Linux-x86 --ropchain
RUN elf-Linux-x86 --depth 3
RUN elf-Linux-x86 --string "main"
RUN elf-Linux-x86 --string "m..n"
RUN elf-Linux-x86 --opcode c9c3
RUN elf-Linux-x86 --only "mov|ret"
RUN elf-Linux-x86 --only "mov|pop|xor|ret"
RUN elf-Linux-x86 --filter "xchg|add|sub|cmov.*"
RUN elf-Linux-x86 --norop --nosys
RUN elf-Linux-x86 --range 0x08041000-0x08042000
RUN elf-Linux-x86 --string main --range 0x080c9aaa-0x080c9aba
RUN elf-Linux-x86 --memstr "/bin/sh"
RUN elf-Linux-x86 --badbytes "00|01-1f|7f|42"
RUN elf-Linux-x86 --offset 5555e000 --badbytes "00-20|80-ff"
RUN Linux_lib64.so --offset 0xdeadbeef00000000
RUN elf-ARMv7-ls --depth 5
RUN elf-ARM64-bash --depth 5
RUN elf-PPC64-bash --depth 5
```

With this patch, the test suite runs successfully on little endian and big endian machines.