### PR TITLE
Add LDM / LDMDB JOP gadgets for ARM Thumb2

### DIFF
--- a/ropgadget/gadgets.py
+++ b/ropgadget/gadgets.py
@@ -288,13 +288,17 @@ class Gadgets(object):
                     gadgets = [
                                [b"\x47[\x00\x08\x10\x18\x20\x28\x30\x38\x40\x48\x70]{1}", 2, 2], # bx   reg
                                [b"\x47[\x80\x88\x90\x98\xa0\xa8\xb0\xb8\xc0\xc8\xf0]{1}", 2, 2], # blx  reg
-                               [b"\xbd[\x00-\xff]{1}", 2, 2]                                     # pop {,pc}
+                               [b"\xbd[\x00-\xff]{1}", 2, 2],                                    # pop {,pc}
+                               [b"\xe8[\x90-\x9f\xb0-\xbf][\x00-\xff]{4}", 4, 2],                # ldm.w reg{!}, {,pc}
+                               [b"\xe9[\x10-\x1f\x30-\x3f][\x00-\xff]{4}", 4, 2]                 # ldmdb reg{!}, {,pc}
                               ]
                 else:
                     gadgets = [
                                [b"[\x00\x08\x10\x18\x20\x28\x30\x38\x40\x48\x70]{1}\x47", 2, 2], # bx   reg
                                [b"[\x80\x88\x90\x98\xa0\xa8\xb0\xb8\xc0\xc8\xf0]{1}\x47", 2, 2], # blx  reg
-                               [b"[\x00-\xff]{1}\xbd", 2, 2]                                     # pop {,pc}
+                               [b"[\x00-\xff]{1}\xbd", 2, 2],                                    # pop {,pc}
+                               [b"[\x90-\x9f\xb0-\xbf]\xe8[\x00-\xff]{4}", 4, 2],                # ldm.w reg{!}, {,pc}
+                               [b"[\x10-\x1f\x30-\x3f]\xe9[\x00-\xff]{4}", 4, 2]                 # ldmdb reg{!}, {,pc}
                               ]
                 arch_mode = CS_MODE_THUMB
             else:

--- a/test-suite-binaries/test.sh
+++ b/test-suite-binaries/test.sh
@@ -57,6 +57,8 @@ echo "RUN Linux_lib64.so --offset 0xdeadbeef00000000" | tee -a  ./test_output
 $RUN --binary ./Linux_lib64.so --offset 0xdeadbeef00000000 1>> ./test_output
 echo "RUN elf-ARMv7-ls --depth 5" | tee -a  ./test_output
 $RUN --binary ./elf-ARMv7-ls --depth 5 1>> ./test_output
+echo "RUN elf-ARMv7-ls --thumb --depth 5" | tee -a  ./test_output
+$RUN --binary ./elf-ARMv7-ls --thumb --depth 5 1>> ./test_output
 echo "RUN elf-ARM64-bash --depth 5" | tee -a  ./test_output
 $RUN --binary ./elf-ARM64-bash --depth 5 1>> ./test_output
 echo "RUN elf-PPC64-bash --depth 5" | tee -a  ./test_output


### PR DESCRIPTION
Currently, ROPgadget does not include any pattern to detect LDM gadgets in Thumb mode for ARM. Such gadgets can be very useful for JOP in arm32 targets, and Thumb mode vastly increases their availability. LDM gadgets in Thumb2 (32-bit encoding) can also act as nice stack pivots, for instance:

```
ldm.w r8!, {r0, r1, r2, r3, r4, r5, r6, r7, r8, sb, fp, sp, lr, pc}
```

On the `elf-ARMv7-ls` test binary, running ROPgadget with `--thumb`, the number of gadgets found increases from 131 to 2387, and the number of `ldm.w` gadgets (`--only ldm.w`) increases from 0 to 29.
