### PR TITLE
Fix SyntaxWarning in Python 3.13

### DIFF
--- a/ropgadget/updateAlert.py
+++ b/ropgadget/updateAlert.py
@@ -27,8 +27,8 @@ class UpdateAlert(object):
             print("Can't connect to raw.githubusercontent.com")
             return
         d = conn.getresponse().read().decode()
-        majorVersion = re.search("MAJOR_VERSION.+=.+(?P<value>[\d])", d).group("value")
-        minorVersion = re.search("MINOR_VERSION.+=.+(?P<value>[\d])", d).group("value")
+        majorVersion = re.search(r"MAJOR_VERSION.+=.+(?P<value>[\d])", d).group("value")
+        minorVersion = re.search(r"MINOR_VERSION.+=.+(?P<value>[\d])", d).group("value")
         webVersion = int("%s%s" % (majorVersion, minorVersion))
         curVersion = int("%s%s" % (MAJOR_VERSION, MINOR_VERSION))
         if webVersion > curVersion:


### PR DESCRIPTION
`SyntaxWarning: invalid escape sequence '\d'`