### PR TITLE
fix callPreceded filtering (#213)

### DIFF
--- a/ropgadget/options.py
+++ b/ropgadget/options.py
@@ -7,6 +7,7 @@
 ##
 
 import codecs
+from functools import reduce
 import re
 from struct import pack
 
@@ -102,18 +103,18 @@ class Options(object):
             prevBytes = gadget["prev"]
             # TODO: Improve / Semantically document each of these cases.
             callPrecededExpressions = [
-                "\xe8[\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff]$",
-                "\xe8[\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff]$",
-                "\xff[\x00-\xff]$",
-                "\xff[\x00-\xff][\x00-\xff]$",
-                "\xff[\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff]$",
-                "\xff[\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff]$",
+                b"\xe8[\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff]$",
+                b"\xe8[\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff]$",
+                b"\xff[\x00-\xff]$",
+                b"\xff[\x00-\xff][\x00-\xff]$",
+                b"\xff[\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff]$",
+                b"\xff[\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff][\x00-\xff]$",
             ]
             return bool(reduce(lambda x, y: x or y, map(lambda x: re.search(x, prevBytes), callPrecededExpressions)))
         arch = self.__binary.getArch()
         if arch == CS_ARCH_X86:
             initial_length = len(self.__gadgets)
-            self.__gadgets = filter(__isGadgetCallPreceded, self.__gadgets)
+            self.__gadgets = list(filter(__isGadgetCallPreceded, self.__gadgets))
             print("Options().removeNonCallPreceded(): Filtered out {} gadgets.".format(initial_length - len(self.__gadgets)))
         else:
             print("Options().removeNonCallPreceded(): Unsupported architecture.")


### PR DESCRIPTION
```
$ python ROPgadget.py --binary ntdll.dll --callPreceded | head -10
Options().removeNonCallPreceded(): Filtered out 70230 gadgets.
Gadgets information
============================================================
0x00000001800c2bcc : adc ah, al ; std ; call qword ptr [rax - 0x5268d17]
0x0000000180018016 : adc al, 0 ; add al, byte ptr [rax] ; add byte ptr [rax], al ; jmp 0x180017ffb
0x000000018001802e : adc al, 0 ; jmp 0x180017ff6
0x00000001801071d8 : adc al, 0x1a ; add byte ptr [rax], al ; jmp 0x1801072e6
0x000000018000d82e : adc al, 0x24 ; xor r12d, r12d ; jmp 0x18000cfbf
0x000000018005a648 : adc al, 0x41 ; add al, 0 ; jmp 0x18005a607
0x00000001800c9b94 : adc al, 0x42 ; jne 0x1800c9b8e ; lea r11d, [rax + 1] ; jmp 0x1800827bb
```