### PR TITLE
Fix capstone v6 alpha7+ CS_MODE_RISCVC rename

### DIFF
--- a/ropgadget/gadgets.py
+++ b/ropgadget/gadgets.py
@@ -9,6 +9,11 @@
 import re
 
 from capstone import *
+# CS_MODE_RISCVC to CS_MODE_RISCV_C in capstone v6 for backwards/forwards compat
+try:
+    CS_MODE_RISCVC
+except NameError:
+    from capstone import CS_MODE_RISCV_C as CS_MODE_RISCVC
 
 
 class Gadgets(object):

--- a/ropgadget/loaders/raw.py
+++ b/ropgadget/loaders/raw.py
@@ -7,6 +7,11 @@
 ##
 
 from capstone import *
+# CS_MODE_RISCVC to CS_MODE_RISCV_C in capstone v6 for backwards/forwards compat
+try:
+    CS_MODE_RISCVC
+except NameError:
+    from capstone import CS_MODE_RISCV_C as CS_MODE_RISCVC
 
 
 class Raw(object):


### PR DESCRIPTION
Users on capstone v6 alpha7+ are broken because `CS_MODE_RISCVC` was
removed and renamed to `CS_MODE_RISCV_C` with no backward compat
`#define`. Users on older capstone have only the old name. The rename
straddles v6 alpha versions, and `CS_API_MAJOR` is 6 on all of them,
so version-detection `#if`s can't distinguish.

Add `try/except NameError` after `from capstone import *` to try the
old name first, falling back to the new name. This now works on all
capstone versions from 5.x through the next release.

Ran the full test suite cleanly with capstone 6.0.0 for all
architectures.
