### PR TITLE
Add CS_ARCH_ARM64 -> CS_ARCH_AARCH64 backward compat for capstone v6

### DIFF
--- a/ropgadget/gadgets.py
+++ b/ropgadget/gadgets.py
@@ -14,6 +14,11 @@ try:
     CS_MODE_RISCVC
 except NameError:
     from capstone import CS_MODE_RISCV_C as CS_MODE_RISCVC
+# CS_ARCH_ARM64 to CS_ARCH_AARCH64 in capstone v6 for backwards/forwards compat
+try:
+    CS_ARCH_ARM64
+except NameError:
+    from capstone import CS_ARCH_AARCH64 as CS_ARCH_ARM64
 
 
 class Gadgets(object):

--- a/ropgadget/loaders/elf.py
+++ b/ropgadget/loaders/elf.py
@@ -9,6 +9,11 @@
 from ctypes import *
 
 from capstone import *
+# CS_ARCH_ARM64 to CS_ARCH_AARCH64 in capstone v6 for backwards/forwards compat
+try:
+    CS_ARCH_ARM64
+except NameError:
+    from capstone import CS_ARCH_AARCH64 as CS_ARCH_ARM64
 
 
 class ELFFlags(object):

--- a/ropgadget/loaders/macho.py
+++ b/ropgadget/loaders/macho.py
@@ -9,6 +9,11 @@
 from ctypes import *
 
 from capstone import *
+# CS_ARCH_ARM64 to CS_ARCH_AARCH64 in capstone v6 for backwards/forwards compat
+try:
+    CS_ARCH_ARM64
+except NameError:
+    from capstone import CS_ARCH_AARCH64 as CS_ARCH_ARM64
 
 
 class MACH_HEADER_LE(LittleEndianStructure):

--- a/ropgadget/loaders/raw.py
+++ b/ropgadget/loaders/raw.py
@@ -12,6 +12,11 @@ try:
     CS_MODE_RISCVC
 except NameError:
     from capstone import CS_MODE_RISCV_C as CS_MODE_RISCVC
+# CS_ARCH_ARM64 to CS_ARCH_AARCH64 in capstone v6 for backwards/forwards compat
+try:
+    CS_ARCH_ARM64
+except NameError:
+    from capstone import CS_ARCH_AARCH64 as CS_ARCH_ARM64
 
 
 class Raw(object):


### PR DESCRIPTION
CS_ARCH_ARM64 was renamed to CS_ARCH_AARCH64 in capstone v6
alpha7+ with no backward compatibility alias.  Four files in
ROPgadget reference CS_ARCH_ARM64: gadgets.py, loaders/elf.py,
loaders/macho.py, loaders/raw.py.

Add try/except NameError after `from capstone import *` in all
four files to define CS_ARCH_ARM64 = CS_ARCH_AARCH64 when the
old name is absent.

This uses the same compat pattern as the CS_MODE_RISCVC fix in
PR #223 and works on every capstone version.

Verified on 6.0.0a6 and 5.0.9 with identical output.